### PR TITLE
Show popup errors and navigation fixes

### DIFF
--- a/Asobi/ContentView.swift
+++ b/Asobi/ContentView.swift
@@ -10,11 +10,13 @@ import SwiftUIX
 
 struct ContentView: View {
     @StateObject var model: WebViewModel = WebViewModel()
+    @AppStorage("navigationAccent") var navigationAccent: Color = .red
 
     var body: some View {
         ZStack {
             // Open cubari on launch
             WebView(webView: model.webView, errorDescription: $model.errorDescription, showError: $model.showError, showNavigation: $model.showNavigation, showProgress: $model.showProgress)
+                .edgesIgnoringSafeArea(.bottom)
                 .zIndex(0)
             
             // ProgressView for loading
@@ -23,7 +25,7 @@ struct ContentView: View {
                     VStack {
                         CircularProgressBar(model.webView.estimatedProgress)
                             .lineWidth(6)
-                            .foregroundColor(.blue)
+                            .foregroundColor(navigationAccent)
                             .frame(width: 60, height: 60)
                         
                         Text("Loading...")
@@ -33,22 +35,32 @@ struct ContentView: View {
                 .zIndex(1)
             }
             
-            // Error description view
-            if model.showError {
-                GroupBox {
+            VStack {
+                Spacer()
+                
+                // Error description view
+                if model.showError {
                     VStack {
-                        Text("Error: \(model.errorDescription!)")
-                        Text("Make sure the default URL in settings is correct!")
+                        GroupBox {
+                            Text("Error: \(model.errorDescription!)")
+                        }
                     }
+                    .transition(AnyTransition.move(edge: .bottom))
+                    .animation(.easeInOut(duration: 0.3))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                            model.showError = false
+                        }
+                    }
+                    .padding()
                 }
-                .zIndex(2)
+                
+                if model.showNavigation {
+                    NavigationBarView()
+                }
             }
-            
-            // Navigation bar view
-            if model.showNavigation {
-                NavigationBarView()
-                    .zIndex(3)
-            }
+            .edgesIgnoringSafeArea(.bottom)
+            .zIndex(2)
         }
         .environmentObject(model)
     }

--- a/Asobi/Extensions/UIDevice.swift
+++ b/Asobi/Extensions/UIDevice.swift
@@ -29,4 +29,12 @@ extension UIDevice {
         }
     #endif
     }
+    
+    var hasNotch: Bool {
+        if #available(iOS 11.0, *) {
+            let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+            return keyWindow?.safeAreaInsets.bottom ?? 0 > 0
+        }
+        return false
+    }
 }

--- a/Asobi/NavigationBarView.swift
+++ b/Asobi/NavigationBarView.swift
@@ -16,8 +16,6 @@ struct NavigationBarView: View {
     
     var body: some View { 
         VStack {
-            Spacer()
-
             // Sets button position depending on hand mode setting
             HStack {
                 if leftHandMode {
@@ -32,9 +30,9 @@ struct NavigationBarView: View {
                         RefreshButtonView()
                         Spacer()
                     }
-                    HomeButtonView()
-                    Spacer()
                     LibraryButtonView()
+                    Spacer()
+                    HomeButtonView()
                     if horizontalSizeClass == .regular {
                         Spacer()
                     }
@@ -42,9 +40,9 @@ struct NavigationBarView: View {
                     if horizontalSizeClass == .regular {
                         Spacer()
                     }
-                    LibraryButtonView()
-                    Spacer()
                     HomeButtonView()
+                    Spacer()
+                    LibraryButtonView()
                     Spacer()
                     if UIDevice.current.userInterfaceIdiom == .pad {
                         RefreshButtonView()
@@ -59,6 +57,7 @@ struct NavigationBarView: View {
                 }
             }
             .padding()
+            .padding(.bottom, UIDevice.current.hasNotch ? 30 : 0)
             .background(colorScheme == .light ? Color.white : Color.black)
             .accentColor(navigationAccent)
         }

--- a/Asobi/SettingsView.swift
+++ b/Asobi/SettingsView.swift
@@ -26,7 +26,7 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Navigation Bar"),
+                Section(header: Text("Appearance"),
                         footer: Text("Some of these settings will cause the menu to close. This is because the parent navigation bar is refreshing.")) {
                     Toggle(isOn: $leftHandMode) {
                         Text("Left handed mode")
@@ -34,7 +34,7 @@ struct SettingsView: View {
                     Toggle(isOn: $persistNavigation) {
                         Text("Lock navigation bar")
                     }
-                    ColorPicker("Navigation bar accent color", selection: $navigationAccent, supportsOpacity: false)
+                    ColorPicker("Accent color", selection: $navigationAccent, supportsOpacity: false)
                 }
                 Section(header: Text("Blockers"),
                         footer: Text("Only enable adblock if you need it! This will cause app launching to become somewhat slower.")) {

--- a/Asobi/WebViewModel.swift
+++ b/Asobi/WebViewModel.swift
@@ -44,6 +44,7 @@ class WebViewModel: ObservableObject {
         webView.isOpaque = false
         webView.backgroundColor = .clear
         webView.scrollView.backgroundColor = UIColor.clear
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
         
         setUserAgent(changeUserAgent: changeUserAgent)
         


### PR DESCRIPTION
Closes #13. Makes popup errors look pretty along with extending the WebView to the full bottom length of the screen.